### PR TITLE
Add post list view

### DIFF
--- a/app/src/main/java/com/example/quack_market/adapter/BoardPostAdapter.kt
+++ b/app/src/main/java/com/example/quack_market/adapter/BoardPostAdapter.kt
@@ -1,0 +1,68 @@
+package com.example.quack_market.adapter
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.example.quack_market.databinding.PostItemBinding
+import com.example.quack_market.navigation.PostModel
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class BoardPostAdapter() : ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(diffUtil) {
+    inner class ViewHolder(private val binding: PostItemBinding): RecyclerView.ViewHolder(binding.root) {
+
+        @SuppressLint("SimpleDateFormat")
+        fun bind(postModel: PostModel) {
+            try {
+                val date = Date()
+                val formattedDate = SimpleDateFormat("MM월 dd일", Locale.getDefault()).format(date)
+
+                binding.boardDateTextView.text = formattedDate
+            } catch (e: IllegalArgumentException) {
+                e.printStackTrace()
+                binding.boardDateTextView.text = "날짜 형식 오류"
+            }
+
+            // 나머지 코드는 그대로 유지
+            binding.boardTitleTextView.text = postModel.title
+            binding.boardPriceTextView.text = postModel.price.toString() + " 원"
+
+            if (postModel.imageUrl.isNotEmpty()) {
+                Glide.with(binding.boardPostImageView)
+                    .load(postModel.imageUrl)
+                    .into(binding.boardPostImageView)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            PostItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(currentList[position])
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<PostModel>() {
+            override fun areItemsTheSame(oldItem: PostModel, newItem: PostModel): Boolean {
+                return oldItem.createdAt == newItem.createdAt
+            }
+
+            override fun areContentsTheSame(oldItem: PostModel, newItem: PostModel): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/quack_market/navigation/BoardFragment.kt
+++ b/app/src/main/java/com/example/quack_market/navigation/BoardFragment.kt
@@ -1,22 +1,111 @@
 package com.example.quack_market.navigation
 
 import android.os.Bundle
-import android.view.LayoutInflater
+import android.util.Log
 import android.view.View
-import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.quack_market.R
+import com.example.quack_market.adapter.BoardPostAdapter
 import com.example.quack_market.databinding.FragmentBoardBinding
+import com.example.quack_market.navigation.DBKey.Companion.DB_POST
+import com.example.quack_market.navigation.DBKey.Companion.DB_USERS
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
+import com.google.firebase.database.ChildEventListener
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.ValueEventListener
+import com.google.firebase.database.database
+import java.util.Date
 
-class BoardFragment : Fragment() {
+class DBKey {
+    companion object {
+        const val DB_POST = "post"
+        const val DB_USERS = "users"
+    }
+}
+
+data class PostModel(
+    val title: String,
+    val imageUrl: String,
+    val price: Long,
+    val createdAt: String
+) {
+    constructor() : this("", "", 0, "")
+}
+
+class BoardFragment : Fragment(R.layout.fragment_board) {
     private lateinit var mBinding: FragmentBoardBinding
+    private lateinit var boardPostAdapter: BoardPostAdapter
+    private lateinit var boardPostDB: DatabaseReference
+    private lateinit var userDB: DatabaseReference
+    private val postList = mutableListOf<PostModel>()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        mBinding = FragmentBoardBinding.inflate(inflater, container, false)
+    private val auth: FirebaseAuth by lazy {
+        Firebase.auth
+    }
 
-        return mBinding.root
+    private val listener = object : ChildEventListener {
+        override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {
+            val postModel = snapshot.getValue(PostModel::class.java)
+            postModel?.let {
+                Log.d(TAG, "onChildAdded: $postModel")
+
+                if (!postList.contains(it)) {
+                    postList.add(it)
+                    boardPostAdapter.submitList(postList.toList())
+                }
+            }
+        }
+
+        override fun onChildChanged(snapshot: DataSnapshot, previousChildName: String?) {
+            // 변경 사항이 있는 경우 처리
+        }
+
+        override fun onChildRemoved(snapshot: DataSnapshot) {
+            // 삭제된 경우 처리
+        }
+
+        override fun onChildMoved(snapshot: DataSnapshot, previousChildName: String?) {
+            // 이동된 경우 처리
+        }
+
+        override fun onCancelled(error: DatabaseError) {
+            Log.e(TAG, "값을 읽어오지 못했습니다.", error.toException())
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val fragmentBoardBinding = FragmentBoardBinding.bind(view)
+        mBinding = fragmentBoardBinding
+
+        boardPostDB = Firebase.database.reference.child(DB_POST)
+        userDB = Firebase.database.reference.child(DB_USERS)
+        boardPostAdapter = BoardPostAdapter()
+
+        fragmentBoardBinding.boardPostRecyclerView.layoutManager = LinearLayoutManager(context)
+        fragmentBoardBinding.boardPostRecyclerView.adapter = boardPostAdapter
+
+        boardPostDB.addChildEventListener(listener)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onResume() {
+        super.onResume()
+        boardPostAdapter.notifyDataSetChanged()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        boardPostDB.removeEventListener(listener)
+    }
+
+    companion object {
+        private const val TAG = "BoardFragment"
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
         android:id="@+id/frame_main"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/bnv_main"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_board.xml
+++ b/app/src/main/res/layout/fragment_board.xml
@@ -10,45 +10,63 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/marketTitleTextView"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/constraintLayout"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="18dp"
-            android:layout_marginTop="25dp"
-            android:fontFamily="@font/suit_bold"
-            android:gravity="top"
-            android:text="꽉구마켓"
-            android:textColor="@color/black"
-            android:textSize="20sp"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/sortTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
-            android:layout_marginEnd="50dp"
-            android:fontFamily="@font/suit_regular"
-            android:text="정렬하기"
-            android:textColor="@color/black"
-            android:textSize="13sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            <TextView
+                android:id="@+id/boardMarketTitleTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp"
+                android:layout_marginTop="20dp"
+                android:fontFamily="@font/suit_bold"
+                android:gravity="top"
+                android:text="꽉구마켓"
+                android:textColor="@color/black"
+                android:textSize="20sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/priceTextView"
-            android:layout_width="wrap_content"
+            <TextView
+                android:id="@+id/boardSortTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="@font/suit_regular"
+                android:text="정렬하기"
+                android:textColor="@color/black"
+                android:textSize="13sp"
+                app:layout_constraintEnd_toStartOf="@+id/boardPriceSettingTextView"
+                app:layout_constraintTop_toTopOf="@+id/boardPriceSettingTextView" />
+
+            <TextView
+                android:id="@+id/boardPriceSettingTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="50dp"
+                android:layout_marginEnd="10dp"
+                android:fontFamily="@font/suit_regular"
+                android:text="가격"
+                android:textColor="@color/black"
+                android:textSize="13sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/boardPostRecyclerView"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
-            android:layout_marginEnd="18dp"
-            android:fontFamily="@font/suit_regular"
-            android:text="가격"
-            android:textColor="@color/black"
-            android:textSize="13sp"
+            app:layout_constrainedHeight="true"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/constraintLayout" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/post_item.xml
+++ b/app/src/main/res/layout/post_item.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="10dp"
+        android:background="#424242"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/boardPostImageView" />
+
+    <ImageView
+        android:id="@+id/boardPostImageView"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@mipmap/ic_launcher" />
+
+    <TextView
+        android:id="@+id/boardTitleTextView"
+        android:layout_width="280dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:maxLines="2"
+        android:text="글 제목"
+        app:layout_constraintStart_toEndOf="@+id/boardPostImageView"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/boardDateTextView"
+        android:layout_width="280dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:text="날짜"
+        app:layout_constraintStart_toStartOf="@+id/boardTitleTextView"
+        app:layout_constraintTop_toBottomOf="@+id/boardTitleTextView" />
+
+    <TextView
+        android:id="@+id/boardPriceTextView"
+        android:layout_width="280dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:text="가격"
+        app:layout_constraintStart_toStartOf="@+id/boardDateTextView"
+        app:layout_constraintTop_toBottomOf="@+id/boardDateTextView" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 개요
메인에서 목록을 띄우도록 개발했습니다.

## 작업 내용
리사이클러뷰를 이용해 파이어베이스에서 post 를 가져와서 띄웁니다.

### 추가된 사항
리사이클러뷰에 post 아이템을 띄우는 BoardPostAdapter 를 추가했습니다.
프래그먼트에서 리사이클러뷰를 이용하는 코드를 추가했습니다.

### 변경 사항
액티비티 메인에서 바텀 네비게이션에 콘텐츠가 가리지 않도록 하단 constarint 를 추가했습니다.

## 이미지
![image](https://github.com/BEOMProject/quack-market/assets/83108398/0d8bebd1-7d1e-48f3-b30d-d07650024022)
