### PR TITLE
Add sold items toggle

### DIFF
--- a/app/src/main/java/com/example/quack_market/adapter/BoardPostAdapter.kt
+++ b/app/src/main/java/com/example/quack_market/adapter/BoardPostAdapter.kt
@@ -1,36 +1,41 @@
 package com.example.quack_market.adapter
 
 import android.annotation.SuppressLint
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.quack_market.databinding.PostItemBinding
 import com.example.quack_market.navigation.PostModel
+import java.text.DecimalFormat
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 
 class BoardPostAdapter() : ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(diffUtil) {
     inner class ViewHolder(private val binding: PostItemBinding): RecyclerView.ViewHolder(binding.root) {
 
-        @SuppressLint("SimpleDateFormat")
+        @RequiresApi(Build.VERSION_CODES.O)
+        @SuppressLint("SimpleDateFormat", "SetTextI18n")
         fun bind(postModel: PostModel) {
-            try {
-                val date = Date()
-                val formattedDate = SimpleDateFormat("MM월 dd일", Locale.getDefault()).format(date)
+            val date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).parse(postModel.createdAt)
+            val formatDate = date?.let { SimpleDateFormat("MM월 dd일", Locale.getDefault()).format(it) }
+            binding.boardDateTextView.text = formatDate
 
-                binding.boardDateTextView.text = formattedDate
-            } catch (e: IllegalArgumentException) {
-                e.printStackTrace()
-                binding.boardDateTextView.text = "날짜 형식 오류"
-            }
-
-            // 나머지 코드는 그대로 유지
             binding.boardTitleTextView.text = postModel.title
-            binding.boardPriceTextView.text = postModel.price.toString() + " 원"
+
+            if (postModel.onSale) {
+                val decimal = DecimalFormat("#,###")
+                binding.boardPriceTextView.text = decimal.format(postModel.price).toString() + " 원"
+            }
+            else {
+                binding.boardPriceTextView.text = "판매 완료"
+            }
 
             if (postModel.imageUrl.isNotEmpty()) {
                 Glide.with(binding.boardPostImageView)
@@ -50,6 +55,7 @@ class BoardPostAdapter() : ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(d
         )
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(currentList[position])
     }

--- a/app/src/main/res/layout/fragment_board.xml
+++ b/app/src/main/res/layout/fragment_board.xml
@@ -33,25 +33,13 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                android:id="@+id/boardSortTextView"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="16dp"
-                android:fontFamily="@font/suit_regular"
-                android:text="정렬하기"
-                android:textColor="@color/black"
-                android:textSize="13sp"
-                app:layout_constraintEnd_toStartOf="@+id/boardPriceSettingTextView"
-                app:layout_constraintTop_toTopOf="@+id/boardPriceSettingTextView" />
-
-            <TextView
-                android:id="@+id/boardPriceSettingTextView"
+                android:id="@+id/boardIsSaleTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="50dp"
                 android:layout_marginEnd="10dp"
                 android:fontFamily="@font/suit_regular"
-                android:text="가격"
+                android:text="판매 완료 물품 제외"
                 android:textColor="@color/black"
                 android:textSize="13sp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -65,8 +53,10 @@
             app:layout_constrainedHeight="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/constraintLayout" />
+            app:layout_constraintTop_toBottomOf="@+id/constraintLayout"
+            app:layout_constraintVertical_bias="0.0" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## 개요
판매 완료 상품 필터링 할 수 있는 토글을 추가했습니다.

## 작업 내용
우측 상단 판매 완료 물품 제외 텍스트를 누르면 판매중인 물품만 볼 수 있도록 했습니다.
기타 디테일한 부분도 수정했습니다.

### 추가된 사항
우측 텍스트뷰를 누르면 판매 완료된 물품을 보기 여부를 선택할 수 있습니다.
판매 완료 물품은 가격 대신 판매 완료 텍스트가 뜨도록 했습니다.

### 변경 사항
우측 상단 텍스트뷰를 2개 -> 1개로 수정했습니다.
판매 글 보기가 날짜 역순으로 정렬되도록 수정했습니다.
게시글 등록 날짜가 정상적으로 뜨도록 수정했습니다.
가격 숫자 포맷이 3글자마다 콤마(,)가 추가되도록 했습니다.

## 이미지
![image](https://github.com/BEOMProject/quack-market/assets/83108398/3511b39a-285d-4090-a58c-6c42a9c5e515)
