### PR TITLE
Add detailed view when clicking on a post in the list

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,123 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/app/src/main/java/com/example/quack_market/adapter/BoardPostAdapter.kt
+++ b/app/src/main/java/com/example/quack_market/adapter/BoardPostAdapter.kt
@@ -10,14 +10,19 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.quack_market.databinding.PostItemBinding
+import com.example.quack_market.navigation.BoardFragment
 import com.example.quack_market.navigation.PostModel
 import java.text.DecimalFormat
 import java.text.SimpleDateFormat
-import java.time.format.DateTimeFormatter
-import java.util.Date
 import java.util.Locale
 
-class BoardPostAdapter() : ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(diffUtil) {
+class BoardPostAdapter(private val context: BoardFragment, private val itemClickListener: OnPostItemClickListener) :
+    ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(diffUtil) {
+
+    interface OnPostItemClickListener {
+        fun onPostItemClick(postModel: PostModel)
+    }
+
     inner class ViewHolder(private val binding: PostItemBinding): RecyclerView.ViewHolder(binding.root) {
 
         @RequiresApi(Build.VERSION_CODES.O)
@@ -31,7 +36,7 @@ class BoardPostAdapter() : ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(d
 
             if (postModel.onSale) {
                 val decimal = DecimalFormat("#,###")
-                binding.boardPriceTextView.text = decimal.format(postModel.price).toString() + " 원"
+                binding.boardPriceTextView.text = decimal.format(postModel.price).toString()+"원"
             }
             else {
                 binding.boardPriceTextView.text = "판매 완료"
@@ -41,6 +46,10 @@ class BoardPostAdapter() : ListAdapter<PostModel, BoardPostAdapter.ViewHolder>(d
                 Glide.with(binding.boardPostImageView)
                     .load(postModel.imageUrl)
                     .into(binding.boardPostImageView)
+            }
+
+            binding.root.setOnClickListener {
+                itemClickListener.onPostItemClick(postModel)
             }
         }
     }

--- a/app/src/main/java/com/example/quack_market/navigation/SalesPostFragment.kt
+++ b/app/src/main/java/com/example/quack_market/navigation/SalesPostFragment.kt
@@ -1,0 +1,86 @@
+package com.example.quack_market.navigation
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
+import com.example.quack_market.R
+import com.example.quack_market.databinding.FragmentSalespostBinding
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
+import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class SalesPostFragment : Fragment(R.layout.fragment_salespost) {
+
+    private var _binding: FragmentSalespostBinding? = null
+    private val binding get() = _binding!!
+
+    companion object {
+        private const val ARG_POST_MODEL = "postModel"
+
+        fun newInstance(postModel: PostModel): SalesPostFragment {
+            val fragment = SalesPostFragment()
+            val args = Bundle()
+            args.putParcelable(ARG_POST_MODEL, postModel)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentSalespostBinding.bind(view)
+
+        val auth: FirebaseAuth = Firebase.auth
+        val currentUser = auth.currentUser
+
+        val postModel: PostModel? = arguments?.getParcelable(ARG_POST_MODEL)
+
+        if (postModel != null) {
+            binding.saleName.text = postModel.title
+
+            val decimal = DecimalFormat("#,###")
+            binding.priceChange.text = decimal.format(postModel.price).toString()+"원"
+
+            if (postModel.onSale) {
+                binding.saleStatus.text = "판매 중"
+            }
+            else {
+                binding.saleStatus.text = "판매 완료"
+            }
+
+            binding.saleInfo.text = postModel.description
+
+            val date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).parse(postModel.createdAt)
+            val formatDate = date?.let { SimpleDateFormat("yyyy.MM.dd HH:mm 등록", Locale.getDefault()).format(it) }
+            binding.uploadDate.text = formatDate
+
+            if (postModel.imageUrl.isNotEmpty()) {
+                Glide.with(binding.imageView2)
+                    .load(postModel.imageUrl)
+                    .into(binding.imageView2)
+            }
+
+            if (currentUser != null) {
+                val uid = currentUser.uid
+                if (uid == postModel.sellerId) {
+                    binding.saleComplete.text = "수정하기"
+                }
+                else {
+                    binding.saleComplete.text = "채팅 보내기"
+                }
+            } else {
+                binding.saleComplete.text = "로그인 필요"
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/fragment_salespost.xml
+++ b/app/src/main/res/layout/fragment_salespost.xml
@@ -16,13 +16,12 @@
 
     <TextView
         android:id="@+id/priceChange"
-        android:layout_width="120dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="30dp"
         android:layout_marginTop="20dp"
-        android:ems="10"
-        android:text="300,000"
-        android:textSize="30sp"
+        android:text="300,000원"
+        android:textSize="24sp"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/imageView2" />
@@ -31,10 +30,10 @@
         android:id="@+id/saleStatus"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="5dp"
-        android:layout_marginBottom="10dp"
-        android:text="TextView"
-        android:textSize="16sp"
+        android:layout_marginStart="10dp"
+        android:layout_marginBottom="5dp"
+        android:text="판매 중"
+        android:textSize="13sp"
         app:layout_constraintBottom_toBottomOf="@+id/priceChange"
         app:layout_constraintStart_toEndOf="@+id/priceChange" />
 
@@ -43,8 +42,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
-        android:text="TextView"
-        android:textSize="20sp"
+        android:text="제목"
+        android:textSize="16sp"
         app:layout_constraintStart_toStartOf="@+id/priceChange"
         app:layout_constraintTop_toBottomOf="@+id/priceChange" />
 
@@ -53,21 +52,18 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="30dp"
-        android:text="TextView"
+        android:text="날짜"
+        android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="@+id/saleName"
         app:layout_constraintEnd_toEndOf="parent" />
 
     <ScrollView
         android:id="@+id/scrollView2"
-        android:layout_width="358dp"
-        android:layout_height="253dp"
-        android:layout_marginStart="30dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="30dp"
         android:layout_marginEnd="30dp"
-        android:layout_marginBottom="100dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/priceChange"
         app:layout_constraintTop_toBottomOf="@+id/saleName">
 
         <LinearLayout
@@ -79,8 +75,8 @@
                 android:id="@+id/saleInfo"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="TextView"
-                android:textSize="20sp" />
+                android:text="설명"
+                android:textSize="15sp" />
         </LinearLayout>
     </ScrollView>
 
@@ -88,29 +84,13 @@
         android:id="@+id/saleComplete"
         android:layout_width="130dp"
         android:layout_height="30dp"
-        android:layout_marginStart="140dp"
-        android:layout_marginTop="20dp"
         android:layout_marginBottom="50dp"
-        android:padding="0dp"
         android:background="@drawable/bg_clicked_button"
+        android:padding="0dp"
         android:text="채팅 보내기"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/scrollView2"
-        app:layout_constraintVertical_bias="0.75" />
-
-    <Button
-        android:id="@+id/saleChange"
-        android:layout_width="130dp"
-        android:layout_height="30dp"
-        android:layout_marginEnd="140dp"
-        android:layout_marginBottom="50dp"
-        android:padding="0dp"
-        android:background="@drawable/bg_clicked_button"
-        android:text="수정하기"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/saleComplete"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintStart_toStartOf="parent" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 개요
글 목록에서 상세 페이지로 이동하기 위해 구현했습니다.

## 작업 내용
판매 글 목록 화면에서 아이템을 클릭하면 메인 프레임에 포스트 프래그먼트를 띄웁니다.

### 추가된 사항
SalsepostFragment 를 추가했습니다.
프래그먼트로 이동할 때 값을 전달하도록 했습니다.

### 변경 사항
상세 글 페이지 폰트 사이즈를 전체적으로 줄이고 버튼을 하나 없앴으며 constraint를 약간 수정했습니다.
유저가 작성한 게시글인지 확인하고 텍스트를 본인 글이면 수정하기, 다른 유저 글이면 채팅 보내기로 설정합니다.

## 이미지
<img width="257" alt="image" src="https://github.com/BEOMProject/quack-market/assets/83108398/b797a396-4e45-4120-975f-6aeb00add900">